### PR TITLE
chore: refresh npm audit lockfile entries

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "tweetsmadeeasy",
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
@@ -65,14 +66,19 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.2.tgz",
-      "integrity": "sha512-k+V+hzjm5q/Mr8ef/1Y9goCmlsK4I6Sm74teeyGvFk1XrOsbsKLjEdrvny42CZ+a8sXbk8KWpY/bDwS+FLL2UQ==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/array-flatten": {
@@ -1363,7 +1369,8 @@
     "node_modules/passport-twitter": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/passport-twitter/-/passport-twitter-1.0.4.tgz",
-      "integrity": "sha1-AaeZ4fdgvy3knyul+6MigvGJMtc=",
+      "integrity": "sha512-qvdauqCqCJJci82mJ9hZZQ6nAv7aSHV31svL8+9H7mRlDdXCdfU6AARQrmmJu3DRmv9fvIebM7zzxR7mVufN3A==",
+      "license": "MIT",
       "dependencies": {
         "passport-oauth1": "1.x.x",
         "xtraverse": "0.1.x"
@@ -1532,9 +1539,10 @@
       }
     },
     "node_modules/request/node_modules/qs": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+      "version": "6.5.5",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.5.tgz",
+      "integrity": "sha512-mzR4sElr1bfCaPJe7m8ilJ6ZXdDaGoObcYR0ZHSsktM/Lt21MVHj5De30GQH2eiZ1qGRTO7LCAzQsUeXTNexWQ==",
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.6"
       }
@@ -1840,7 +1848,8 @@
     "node_modules/twitter": {
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/twitter/-/twitter-1.7.1.tgz",
-      "integrity": "sha1-B2I3jx3BwFDkj2ZqypBOJLGpYvQ=",
+      "integrity": "sha512-Do7l/WzFnUZC14ABtZfDiOHKl6M9Ft5tE4YF0ev9XLm4yh7m8R98D82rzeDAMjbjMZk2R/tb6sgXXb3sPKoaVw==",
+      "license": "MIT",
       "dependencies": {
         "deep-extend": "^0.5.0",
         "request": "^2.72.0"
@@ -1947,7 +1956,7 @@
     "node_modules/xtraverse": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/xtraverse/-/xtraverse-0.1.0.tgz",
-      "integrity": "sha1-t0G60BjveNip0ug63gB7P3lZxzI=",
+      "integrity": "sha512-MANQdlG2hl1nQobxz1Rv8hsS1RuBS0C1N6qTOupv+9vmfrReePdxhmB2ecYjvsp4stJ80HD7erjkoF1Hd/FK9A==",
       "dependencies": {
         "xmldom": "0.1.x"
       },


### PR DESCRIPTION
## Summary
- Refreshes npm audit-resolvable lockfile entries after the Dependabot merge sweep.
- Keeps the change package-lock-only and avoids breaking dependency upgrades.

## Verification
- npm audit fix --package-lock-only
- git diff --check
- No test script is defined in package.json.