### PR TITLE
Refresh public project documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,57 @@
-# TweetsMadeEasy
-A personalized tweets dashboard.
+﻿# TweetsMadeEasy
 
-# Features Completed
-- Login/Signup with Twitter.
-- Basic User profile UI.
-- People mentioning the user are rendered in left pane.
-- Detailed tweet is rendered in right pane with reply to tweet option.
+TweetsMadeEasy is a social publishing prototype focused on simplifying Twitter account authentication and post workflows through a web interface.
 
-# Installation and Setup
-- `git clone https://github.com/priyamshah112/TweetsMadeEasy.git`
-- `cd TweetsMadeEasy`
-- `npm install`
-- `nodemon index.js`
+## Repository Status
+
+- Current role: Social publishing helper built with Express, EJS, MongoDB sessions, and Twitter authentication
+- Documentation status: refreshed for public review
+- Primary audience: engineers, product reviewers, and collaborators evaluating the project context
+
+## What This Project Does
+
+- Express web application with EJS views
+- Passport Twitter authentication flow
+- MongoDB-backed sessions
+- Twitter API integration path for publishing workflows
+
+## Technology Stack
+
+- Node.js, Express, and EJS
+- MongoDB, connect-mongo, and express-session
+- Passport and passport-twitter
+- twitter package and dotenv-based configuration
+
+## Repository Map
+
+- index.js is the application entry point
+- controllers/ contains route logic
+- views/ contains EJS templates
+- public/ contains static frontend assets
+
+## Getting Started
+
+- Install Node.js and npm
+- Run npm install
+- Create local platform API credentials using safe local values
+- Start the app with npm start
+- Test only against accounts and apps intended for development
+
+## Documentation
+
+- docs/overview.md - product context, users, scope, and outcomes
+- docs/architecture.md - components, data flow, and sequence diagrams
+- docs/product.md - user journeys, requirements, constraints, and roadmap ideas
+- docs/operations.md - setup, validation, maintenance, and known risks
+
+## Known Limitations
+
+- Platform API behavior and pricing have changed over time and must be rechecked before reuse
+- OAuth credentials and callback URLs are environment-specific
+- Automation should include safeguards against accidental or duplicate posts
+
+## Notes For Future Maintainers
+
+This repository documents the original project intent and the implementation shape visible in the codebase. Before production use, review dependencies, environment configuration, data handling, and deployment assumptions against current standards.
+
+

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,45 @@
+﻿# Architecture
+
+The application is a server-rendered Express app. Passport handles Twitter OAuth, MongoDB stores session state, and controller logic coordinates post-related workflows.
+
+## Component View
+
+```mermaid
+flowchart LR
+  Actor["Publisher"] --> Entry["EJS web interface"]
+  Entry --> Service["Express controllers and OAuth middleware"]
+  Service --> Data["MongoDB session store"]
+  Service --> External["Twitter or X API"]
+```
+
+## Key Components
+
+- Express entry point
+- Passport Twitter strategy
+- MongoDB-backed session storage
+- EJS views and static assets
+- Twitter API integration layer
+
+## Main Workflow
+
+```mermaid
+sequenceDiagram
+  participant User
+  participant Client
+  participant App
+  participant Store
+  User->>Client: Authenticates and prepares a post
+  Client->>App: Submits post workflow
+  App->>Store: Validate and persist state
+  Store-->>App: Session and auth state validated
+  App-->>Client: Returns publish result or error
+  Client-->>User: Present updated result
+```
+
+## Design Considerations
+
+- Make user consent explicit
+- Treat platform rate limits and policy changes as core product constraints
+- Keep post preview and confirmation steps separate from API submission
+
+

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1,0 +1,31 @@
+﻿# Operations
+
+These notes capture the practical work needed to run, maintain, or modernize the repository from its current state.
+
+## Local Operation
+
+- Install Node.js and npm
+- Run npm install
+- Create local platform API credentials using safe local values
+- Start the app with npm start
+- Test only against accounts and apps intended for development
+
+## Validation
+
+- Run npm start for local smoke testing
+- Test OAuth callback flow with development credentials only
+- Verify failure messages for denied auth and API errors
+
+## Maintenance Notes
+
+- Re-check current X API terms before reuse
+- Keep API credentials out of source
+- Add tests for OAuth callback and session behavior
+
+## Operational Risks
+
+- Platform API behavior and pricing have changed over time and must be rechecked before reuse
+- OAuth credentials and callback URLs are environment-specific
+- Automation should include safeguards against accidental or duplicate posts
+
+

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,0 +1,27 @@
+﻿# Overview
+
+The project captures an early automation idea around social media publishing: authenticate a user, prepare content, and use platform APIs to reduce repetitive posting work.
+
+## Problem Space
+
+Social publishing tools need to balance convenience with platform API constraints, user consent, rate limits, and clear auditability of what gets posted.
+
+## Primary Users
+
+- Individuals managing social publishing
+- Small teams preparing posts
+- Developers learning OAuth-backed social API flows
+
+## Scope
+
+- Twitter authentication and publishing helper workflows
+- Server-rendered web application structure
+- API-fragility and modernization notes
+
+## Outcomes To Evaluate
+
+- OAuth and posting workflow are understandable
+- Platform dependency risks are visible
+- Modernization path is clear
+
+

--- a/docs/product.md
+++ b/docs/product.md
@@ -1,0 +1,29 @@
+﻿# Product Notes
+
+The product idea is a focused publishing assistant, not a generic social dashboard. Its value comes from reducing repeated steps while staying transparent about platform actions.
+
+## User Journeys
+
+- User signs in with a social account
+- User prepares a post and confirms publication
+- Application handles API response and reports status
+
+## Functional Requirements
+
+- OAuth login and callback handling
+- Session-backed user flow
+- Post creation or publishing action through platform API
+
+## Constraints
+
+- API access terms can change
+- Posting actions must be deliberate and reversible where possible
+- Credential handling must be environment-specific
+
+## Roadmap Ideas
+
+- Add draft and scheduled-post concepts
+- Add provider abstraction for multiple social platforms
+- Add dry-run mode and post history
+
+


### PR DESCRIPTION
## Summary
- Refresh the public README with a neutral project overview, stack, setup notes, and limitations.
- Add standard documentation under docs/ where useful: overview, architecture, product, and operations.
- Keep the content professional and repository-focused without strategy-specific document names.

## Validation
- Documentation-only change.
- Verified README docs links locally across the refresh batch.